### PR TITLE
break on first error in db create

### DIFF
--- a/soda/cmd/create.go
+++ b/soda/cmd/create.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/markbates/pop"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +16,7 @@ var createCmd = &cobra.Command{
 			for _, conn := range pop.Connections {
 				err = pop.CreateDB(conn)
 				if err != nil {
-					break
+					fmt.Println(err)
 				}
 			}
 		} else {

--- a/soda/cmd/create.go
+++ b/soda/cmd/create.go
@@ -8,14 +8,19 @@ import (
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Creates databases for you",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
 		if all {
 			for _, conn := range pop.Connections {
-				pop.CreateDB(conn)
+				err = pop.CreateDB(conn)
+				if err != nil {
+					break
+				}
 			}
 		} else {
-			pop.CreateDB(getConn())
+			err = pop.CreateDB(getConn())
 		}
+		return err
 	},
 }
 


### PR DESCRIPTION
@markbates 

Thanks for the excellent work on this project!  I ran into an issue while trying out Buffalo where soda was unable to create the MySQL DB and silently failed.  This change breaks out of the DB creation loop when it hits an error and returns the error for the user to see.