### PR TITLE
Escape . in nrx regexp

### DIFF
--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -24,7 +24,7 @@ func init() {
 	ModelCmd.Flags().BoolVarP(&skipMigration, "skip-migration", "s", false, "Skip creating a new fizz migration for this model.")
 }
 
-var nrx = regexp.MustCompile(`^nulls.(.+)`)
+var nrx = regexp.MustCompile(`^nulls\.(.+)`)
 
 type names struct {
 	Original string


### PR DESCRIPTION
Judging from the usage around line 241, I think the intention is for a nullable type to be specified as nulls.type. If that's really the case, then the nrx regular expression must escape the dot, as this change does.