### PR TITLE
Avoid wrapping mysql table names in strings

### DIFF
--- a/fizz/translators/mysql.go
+++ b/fizz/translators/mysql.go
@@ -48,14 +48,14 @@ func (p *MySQL) CreateTable(t fizz.Table) (string, error) {
 }
 
 func (p *MySQL) DropTable(t fizz.Table) (string, error) {
-	return fmt.Sprintf("DROP TABLE \"%s\";", t.Name), nil
+	return fmt.Sprintf("DROP TABLE %s;", t.Name), nil
 }
 
 func (p *MySQL) RenameTable(t []fizz.Table) (string, error) {
 	if len(t) < 2 {
 		return "", errors.New("Not enough table names supplied!")
 	}
-	return fmt.Sprintf("ALTER TABLE \"%s\" RENAME TO \"%s\";", t[0].Name, t[1].Name), nil
+	return fmt.Sprintf("ALTER TABLE %s RENAME TO %s;", t[0].Name, t[1].Name), nil
 }
 
 func (p *MySQL) AddColumn(t fizz.Table) (string, error) {

--- a/fizz/translators/mysql_test.go
+++ b/fizz/translators/mysql_test.go
@@ -94,7 +94,7 @@ PRIMARY KEY(uuid)
 func (p *MySQLSuite) Test_MySQL_DropTable() {
 	r := p.Require()
 
-	ddl := `DROP TABLE "users";`
+	ddl := `DROP TABLE users;`
 
 	res, _ := fizz.AString(`drop_table("users")`, myt)
 	r.Equal(ddl, res)
@@ -103,7 +103,7 @@ func (p *MySQLSuite) Test_MySQL_DropTable() {
 func (p *MySQLSuite) Test_MySQL_RenameTable() {
 	r := p.Require()
 
-	ddl := `ALTER TABLE "users" RENAME TO "people";`
+	ddl := `ALTER TABLE users RENAME TO people;`
 
 	res, _ := fizz.AString(`rename_table("users", "people")`, myt)
 	r.Equal(ddl, res)


### PR DESCRIPTION
Mysql doesn't allow table names to be strings. For example, the command:
`DROP TABLE "users";`
Results in `You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"users"' at line 1`.

Verified this in v 5.5 and 5.7