### PR TITLE
Fix model.PrimaryKeyType returning invalid type if ID column not found

### DIFF
--- a/model.go
+++ b/model.go
@@ -98,7 +98,7 @@ func (m *Model) ID() interface{} {
 func (m *Model) PrimaryKeyType() string {
 	fbn, err := m.fieldByName("ID")
 	if err != nil {
-		return "integer"
+		return "int"
 	}
 	return fbn.Type().Name()
 }


### PR DESCRIPTION
"integer" is not a type