### PR TITLE
Remove "Connection" singleton

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,8 @@ import (
 func Test_LoadsConnectionsFromConfig(t *testing.T) {
 	r := require.New(t)
 
-	conns := pop.Connections
+	conns, err := pop.LoadConfig()
+	r.Equal(nil, err)
 	r.Equal(4, len(conns))
 }
 

--- a/connection.go
+++ b/connection.go
@@ -10,9 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Connections contains all of the available connections
-var Connections = map[string]*Connection{}
-
 // Connection represents all of the necessary details for
 // talking with a datastore
 type Connection struct {
@@ -57,13 +54,13 @@ func NewConnection(deets *ConnectionDetails) (*Connection, error) {
 }
 
 // Connect takes the name of a connection, default is "development", and will
-// return that connection from the available `Connections`. If a connection with
+// return that connection from the available `connections`. If a connection with
 // that name can not be found an error will be returned. If a connection is
 // found, and it has yet to open a connection with its underlying datastore,
 // a connection to that store will be opened.
-func Connect(e string) (*Connection, error) {
+func Connect(e string, connections map[string]*Connection) (*Connection, error) {
 	e = defaults.String(e, "development")
-	c := Connections[e]
+	c := connections[e]
 	if c == nil {
 		return c, errors.Errorf("Could not find connection named %s!", e)
 	}

--- a/pop_test.go
+++ b/pop_test.go
@@ -49,7 +49,12 @@ func init() {
 	dialect := os.Getenv("SODA_DIALECT")
 
 	var err error
-	PDB, err = pop.Connect(dialect)
+	connections, err := pop.LoadConfig()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	PDB, err = pop.Connect(dialect, connections)
 	if err != nil {
 		log.Panic(err)
 	}


### PR DESCRIPTION
With the singleton you can't use the package without already doing
stuff, e.g. loading and parsing the "database.yml". And if there is
something in "database.yml" POP doesnt like it will die on you with a
panic. So let's the user of POP decide when to actually DO stuff.