### PR TITLE
Remove "Connections" singleton

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,8 @@ import (
 func Test_LoadsConnectionsFromConfig(t *testing.T) {
 	r := require.New(t)
 
-	conns := pop.Connections
+	conns, err := pop.LoadConfig()
+	r.Equal(nil, err)
 	r.Equal(4, len(conns))
 }
 

--- a/connection.go
+++ b/connection.go
@@ -57,17 +57,22 @@ func NewConnection(deets *ConnectionDetails) (*Connection, error) {
 }
 
 // Connect takes the name of a connection, default is "development", and will
-// return that connection from the available `Connections`. If a connection with
-// that name can not be found an error will be returned. If a connection is
-// found, and it has yet to open a connection with its underlying datastore,
-// a connection to that store will be opened.
+// return that connection from the available `Connections` (which will be
+// read from 'database.yml').
+// If a connection with that name can not be found an error will be returned.
+// If a connection is found, and it has yet to open a connection with its
+// underlying datastore, a connection to that store will be opened.
 func Connect(e string) (*Connection, error) {
+	conns, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
 	e = defaults.String(e, "development")
-	c := Connections[e]
+	c := conns[e]
 	if c == nil {
 		return c, errors.Errorf("Could not find connection named %s!", e)
 	}
-	err := c.Open()
+	err = c.Open()
 	return c, errors.Wrapf(err, "couldn't open connection for %s", e)
 }
 

--- a/connection.go
+++ b/connection.go
@@ -10,9 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Connections contains all of the available connections
-var Connections = map[string]*Connection{}
-
 // Connection represents all of the necessary details for
 // talking with a datastore
 type Connection struct {

--- a/connection.go
+++ b/connection.go
@@ -53,23 +53,30 @@ func NewConnection(deets *ConnectionDetails) (*Connection, error) {
 	return c, nil
 }
 
+// map with all possible connections from a 'database.yml'.
+// Will be initialized once in 'Connect'
+var connections map[string]*Connection
+
 // Connect takes the name of a connection, default is "development", and will
-// return that connection from the available `Connections` (which will be
-// read from 'database.yml').
+// return that connection from the available `connections` (which will be
+// read from 'database.yml' once on the first call of 'Connect').
 // If a connection with that name can not be found an error will be returned.
 // If a connection is found, and it has yet to open a connection with its
 // underlying datastore, a connection to that store will be opened.
 func Connect(e string) (*Connection, error) {
-	conns, err := LoadConfig()
-	if err != nil {
-		return nil, err
+	if connections == nil {
+		var err error
+		if connections, err = LoadConfig(); err != nil {
+			return nil, err
+		}
 	}
+
 	e = defaults.String(e, "development")
-	c := conns[e]
+	c := connections[e]
 	if c == nil {
 		return c, errors.Errorf("Could not find connection named %s!", e)
 	}
-	err = c.Open()
+	err := c.Open()
 	return c, errors.Wrapf(err, "couldn't open connection for %s", e)
 }
 

--- a/soda/cmd/create.go
+++ b/soda/cmd/create.go
@@ -13,7 +13,7 @@ var createCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		if all {
-			for _, conn := range pop.Connections {
+			for _, conn := range connections {
 				err = pop.CreateDB(conn)
 				if err != nil {
 					fmt.Println(err)

--- a/soda/cmd/drop.go
+++ b/soda/cmd/drop.go
@@ -12,7 +12,7 @@ var dropCmd = &cobra.Command{
 	Short: "Drops databases for you",
 	Run: func(cmd *cobra.Command, args []string) {
 		if all {
-			for _, conn := range pop.Connections {
+			for _, conn := range connections {
 				pop.DropDB(conn)
 			}
 		} else {

--- a/soda/cmd/root.go
+++ b/soda/cmd/root.go
@@ -13,6 +13,7 @@ import (
 var cfgFile string
 var env string
 var version bool
+var connections map[string]*pop.Connection
 
 var RootCmd = &cobra.Command{
 	Use:     "soda",
@@ -42,6 +43,12 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "The configuration file you would like to use.")
 	RootCmd.PersistentFlags().StringVarP(&env, "env", "e", "development", "The environment you want to run migrations against. Will use $GO_ENV if set.")
 	RootCmd.PersistentFlags().BoolVarP(&pop.Debug, "debug", "d", false, "Use debug/verbose mode")
+
+	var err error
+	connections, err = pop.LoadConfig()
+	if err != nil {
+		panic(err)
+	}
 }
 
 func setConfigLocation() {
@@ -58,7 +65,7 @@ func setConfigLocation() {
 }
 
 func getConn() *pop.Connection {
-	conn := pop.Connections[env]
+	conn := connections[env]
 	if conn == nil {
 		fmt.Printf("There is no connection named %s defined!\n", env)
 		os.Exit(1)


### PR DESCRIPTION
With the singleton you can't use the package without already doing
stuff, e.g. loading and parsing the "database.yml". And if there is
something in "database.yml" POP doesnt like it will die on you with a
panic.

Now the file will be read and parsed when the user tries to make
a connection using "Connect".