### PR TITLE
fix packagePath for call from buffalo

### DIFF
--- a/soda/cmd/generate/config.go
+++ b/soda/cmd/generate/config.go
@@ -48,6 +48,10 @@ func pkgPath() string {
 
 func GenerateConfig(cfgFile string, data map[string]interface{}) error {
 	dialect = strings.ToLower(data["dialect"].(string))
+	packagePath := data["packagePath"].(string)
+	if strings.HasPrefix(dialect, "sqlite") && !strings.HasPrefix(packagePath, "src") {
+		data["packagePath"] = "src/" + packagePath
+	}
 	if t, ok := configTemplates[dialect]; ok {
 		g := makr.New()
 		g.Add(makr.NewFile(cfgFile, t))

--- a/soda/cmd/generate/config_templates.go
+++ b/soda/cmd/generate/config_templates.go
@@ -30,15 +30,15 @@ production:
 
 var sqliteConfig = `development:
   dialect: "sqlite3"
-  database: {{"{{"}}env "GOPATH" {{"}}"}}/src/{{.packagePath}}/{{.name}}_development.sqlite
+  database: {{"{{"}}env "GOPATH" {{"}}"}}/{{.packagePath}}/{{.name}}_development.sqlite
 
 test:
   dialect: "sqlite3"
-  database: {{"{{"}}env "GOPATH" {{"}}"}}/src/{{.packagePath}}/{{.name}}_test.sqlite
+  database: {{"{{"}}env "GOPATH" {{"}}"}}/{{.packagePath}}/{{.name}}_test.sqlite
 
 production:
   dialect: "sqlite3"
-  database: {{"{{"}}env "GOPATH" {{"}}"}}/src/{{.packagePath}}/{{.name}}_production.sqlite`
+  database: {{"{{"}}env "GOPATH" {{"}}"}}/{{.packagePath}}/{{.name}}_production.sqlite`
 
 var configTemplates = map[string]string{
 	"postgres":   pgConfig,

--- a/soda/cmd/generate/config_templates.go
+++ b/soda/cmd/generate/config_templates.go
@@ -30,15 +30,15 @@ production:
 
 var sqliteConfig = `development:
   dialect: "sqlite3"
-  database: {{"{{"}}env "GOPATH" {{"}}"}}/{{.packagePath}}/{{.name}}_development.sqlite
+  database: {{"{{"}}env "GOPATH" {{"}}"}}/src/{{.packagePath}}/{{.name}}_development.sqlite
 
 test:
   dialect: "sqlite3"
-  database: {{"{{"}}env "GOPATH" {{"}}"}}/{{.packagePath}}/{{.name}}_test.sqlite
+  database: {{"{{"}}env "GOPATH" {{"}}"}}/src/{{.packagePath}}/{{.name}}_test.sqlite
 
 production:
   dialect: "sqlite3"
-  database: {{"{{"}}env "GOPATH" {{"}}"}}/{{.packagePath}}/{{.name}}_production.sqlite`
+  database: {{"{{"}}env "GOPATH" {{"}}"}}/src/{{.packagePath}}/{{.name}}_production.sqlite`
 
 var configTemplates = map[string]string{
 	"postgres":   pgConfig,


### PR DESCRIPTION
Adds the src folde to the packagePath if this is not part of it.
Because the packagePath inside from buffalo comes without the src folder.