### PR TITLE
improve error messages when db create/drop fail.

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -58,11 +58,9 @@ func (m *mysql) CreateDB() error {
 	c := m.ConnectionDetails
 	cmd := exec.Command("mysql", "-u", c.User, "-p"+c.Password, "-h", c.Host, "-P", c.Port, "-e", fmt.Sprintf("create database %s", c.Database))
 	Log(strings.Join(cmd.Args, " "))
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stderr
-	cmd.Stdout = os.Stdout
-	err := cmd.Run()
+	comboOut, err := cmd.CombinedOutput()
 	if err != nil {
+		err = fmt.Errorf("%s: %s", err.Error(), string(comboOut))
 		return errors.Wrapf(err, "error creating MySQL database %s", c.Database)
 	}
 	fmt.Printf("created database %s\n", c.Database)
@@ -73,11 +71,9 @@ func (m *mysql) DropDB() error {
 	c := m.ConnectionDetails
 	cmd := exec.Command("mysql", "-u", c.User, "-p"+c.Password, "-h", c.Host, "-P", c.Port, "-e", fmt.Sprintf("drop database %s", c.Database))
 	Log(strings.Join(cmd.Args, " "))
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stderr
-	cmd.Stdout = os.Stdout
-	err := cmd.Run()
+	comboOut, err := cmd.CombinedOutput()
 	if err != nil {
+		err = fmt.Errorf("%s: %s", err.Error(), string(comboOut))
 		return errors.Wrapf(err, "error dropping MySQL database %s", c.Database)
 	}
 	fmt.Printf("dropped database %s\n", c.Database)

--- a/postgresql.go
+++ b/postgresql.go
@@ -76,11 +76,9 @@ func (p *postgresql) CreateDB() error {
 	deets := p.ConnectionDetails
 	cmd := exec.Command("createdb", "-e", "-h", deets.Host, "-p", deets.Port, "-U", deets.User, deets.Database)
 	Log(strings.Join(cmd.Args, " "))
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stderr
-	cmd.Stdout = os.Stdout
-	err := cmd.Run()
+	comboOut, err := cmd.CombinedOutput()
 	if err != nil {
+		err = fmt.Errorf("%s: %s", err.Error(), string(comboOut))
 		return errors.Wrapf(err, "error creating PostgreSQL database %s", deets.Database)
 	}
 
@@ -92,11 +90,9 @@ func (p *postgresql) DropDB() error {
 	deets := p.ConnectionDetails
 	cmd := exec.Command("dropdb", "-e", "-h", deets.Host, "-p", deets.Port, "-U", deets.User, deets.Database)
 	Log(strings.Join(cmd.Args, " "))
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stderr
-	cmd.Stdout = os.Stdout
-	err := cmd.Run()
+	comboOut, err := cmd.CombinedOutput()
 	if err != nil {
+		err = fmt.Errorf("%s: %s", err.Error(), string(comboOut))
 		return errors.Wrapf(err, "error dropping PostgreSQL database %s", deets.Database)
 	}
 	fmt.Printf("dropped database %s\n", deets.Database)


### PR DESCRIPTION
Instead of returning the uninformative "exit status 1" message, when database create and drop operations fail, we return the actual errors from the underlying command stderr and stdout.

While #82 is already (update: only partially) addressed (cockroachdb works as long as you configure database.yml with the root user), this is just icing that would have prevented #82 from being opened in the first place.

~~~
BEFORE:

$ buffalo db create -a -d
v3.23.2

[POP]: Loading config file from /Users/jaten/go/src/github.com/glycerine/my/deal/database.yml
[POP] 2017/06/30 15:37:03 Create deal_development (postgres://postgres:postgres@127.0.0.1:5432/deal_development?sslmode=disable)
[POP] 2017/06/30 15:37:03 createdb -e -h 127.0.0.1 -p 5432 -U postgres deal_development
Usage:
  buffalo db create [flags]

Flags:
  -a, --all    Creates all of the databases in the database.yml
  -h, --help   help for create

Global Flags:
  -c, --config string   The configuration file you would like to use.
  -d, --debug           Use debug/verbose mode
  -e, --env string      The environment you want to run migrations against. Will use $GO_ENV if set. (default "development")
  -p, --path string     Path to the migrations folder (default "./migrations")

Error: couldn't create database deal_development: error creating PostgreSQL database deal_development: exit status 1

$


AFTER example 1:

$  buffalo db create -a 
v3.23.2

Usage:
  buffalo db create [flags]

Flags:
  -a, --all    Creates all of the databases in the database.yml
  -h, --help   help for create

Global Flags:
  -c, --config string   The configuration file you would like to use.
  -d, --debug           Use debug/verbose mode
  -e, --env string      The environment you want to run migrations against. Will use $GO_ENV if set. (default "development")
  -p, --path string     Path to the migrations folder (default "./migrations")

Error: couldn't create database deal_production: error creating PostgreSQL database deal_production: exit status 1: createdb: could not connect to database template1: could not connect to server: Connection refused
	Is the server running on host "127.0.0.1" and accepting
	TCP/IP connections on port 5432?


$


AFTER example 2:

$  buffalo db create -a 
v3.23.2

Usage:
  buffalo db create [flags]

Flags:
  -a, --all    Creates all of the databases in the database.yml
  -h, --help   help for create

Global Flags:
  -c, --config string   The configuration file you would like to use.
  -d, --debug           Use debug/verbose mode
  -e, --env string      The environment you want to run migrations against. Will use $GO_ENV if set. (default "development")
  -p, --path string     Path to the migrations folder (default "./migrations")

Error: couldn't create database deal_development: error creating PostgreSQL database deal_development: exit status 1: createdb: database creation failed: ERROR:  only root is allowed to CREATE DATABASE
CREATE DATABASE deal_development;


$

AFTER example 3:

$  buffalo db create -a 
v3.23.2

Usage:
  buffalo db create [flags]

Flags:
  -a, --all    Creates all of the databases in the database.yml
  -h, --help   help for create

Global Flags:
  -c, --config string   The configuration file you would like to use.
  -d, --debug           Use debug/verbose mode
  -e, --env string      The environment you want to run migrations against. Will use $GO_ENV if set. (default "development")
  -p, --path string     Path to the migrations folder (default "./migrations")

Error: couldn't create database deal_development: error creating PostgreSQL database deal_development: exit status 1: createdb: database creation failed: ERROR:  database "deal_development" already exists
CREATE DATABASE deal_development;


$
~~~
