### PR TITLE
Option to skip Dialect.TranslateSQL

### DIFF
--- a/connection_details.go
+++ b/connection_details.go
@@ -16,6 +16,9 @@ import (
 type ConnectionDetails struct {
 	// Example: "postgres" or "sqlite3" or "mysql"
 	Dialect string
+	// RawPlaceholders disables conversion of `?` to dialect-specific form
+	// of prepared statement placeholders.
+	RawPlaceholders bool
 	// The name of your database. Example: "foo_development"
 	Database string
 	// The host of your database. Example: "127.0.0.1"

--- a/postgresql.go
+++ b/postgresql.go
@@ -124,6 +124,9 @@ func (m *postgresql) MigrationURL() string {
 }
 
 func (p *postgresql) TranslateSQL(sql string) string {
+	if p.ConnectionDetails.RawPlaceholders {
+		return sql
+	}
 	defer p.mu.Unlock()
 	p.mu.Lock()
 


### PR DESCRIPTION
Added `RawPlaceholders` boolean flag to ConnectionDetails,
which disables conversion of `?` to dialec-specific form fo prepared
statement placeholders.