### PR TITLE
Postgresql database creation

### DIFF
--- a/postgresql.go
+++ b/postgresql.go
@@ -75,7 +75,7 @@ func (p *postgresql) SelectMany(s store, models *Model, query Query) error {
 func (p *postgresql) CreateDB() error {
 	// createdb -h db -p 5432 -U postgres enterprise_development
 	deets := p.ConnectionDetails
-	cmd := exec.Command("psql", p.urlWithoutDb(), "-c", fmt.Sprintf("create database %s", deets.Database))
+	cmd := exec.Command("psql", "-c", fmt.Sprintf("create database %s", deets.Database), p.urlWithoutDb())
 	Log(strings.Join(cmd.Args, " "))
 	comboOut, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Hello Mark,

I encountered an issue when i ran `buffalo db create -a` . It displayed the normal message for successful creation of database, but running the application could not create transaction. After checking, I found out non of the database was created.

I got this when I added `fmt.Println(string(comboOut))`

![errorafterdebugging](https://user-images.githubusercontent.com/13089295/30782669-6058fe30-a12e-11e7-9cd2-a52609fdd111.PNG)

Using the create database command with option (-c *command*)  before the postgres URL,
 solved the issue.

I can't confirm if it's only a windows command prompt problem, but this problem occurred on windows.