### PR TITLE
[PostgreSQL] Use SQL instead of psql for create and drop DB

### DIFF
--- a/soda/cmd/drop.go
+++ b/soda/cmd/drop.go
@@ -10,14 +10,19 @@ var all bool
 var dropCmd = &cobra.Command{
 	Use:   "drop",
 	Short: "Drops databases for you",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
 		if all {
 			for _, conn := range pop.Connections {
-				pop.DropDB(conn)
+				err = pop.DropDB(conn)
+				if err != nil {
+					return err
+				}
 			}
 		} else {
-			pop.DropDB(getConn())
+			err = pop.DropDB(getConn())
 		}
+		return err
 	},
 }
 


### PR DESCRIPTION
* db create & db drop can be used without PostgresSQL client (psql)
* ensure drop db errors are displayed to the user 