### PR TITLE
improve database migrations

### DIFF
--- a/fizz/tables.go
+++ b/fizz/tables.go
@@ -42,10 +42,10 @@ func (t *Table) HasColumns(args ...string) bool {
 }
 
 func (f fizzer) CreateTable() interface{} {
-	return func(name string, fn func(t *Table)) {
+	return func(name string, fn func(t *Table), options map[string]interface{}) {
 		t := Table{
 			Name:    name,
-			Columns: []Column{CREATED_COL, UPDATED_COL},
+			Columns: []Column{},
 		}
 		fn(&t)
 		var foundPrimary bool
@@ -55,9 +55,15 @@ func (f fizzer) CreateTable() interface{} {
 				break
 			}
 		}
+
 		if !foundPrimary {
-			t.Columns = append(t.Columns, INT_ID_COL)
+			t.Columns = append([]Column{INT_ID_COL}, t.Columns...)
 		}
+
+		if value, exists := options["timestamps"]; !exists || true == value {
+			t.Columns = append(t.Columns, CREATED_COL, UPDATED_COL)
+		}
+
 		f.add(f.Bubbler.CreateTable(t))
 	}
 }

--- a/fizz/tables.go
+++ b/fizz/tables.go
@@ -4,6 +4,11 @@ type Table struct {
 	Name    string `db:"name"`
 	Columns []Column
 	Indexes []Index
+	Options map[string]interface{}
+}
+
+func (t *Table) DisableTimestamps() {
+	t.Options["timestamps"] = false
 }
 
 func (t *Table) Column(name string, colType string, options map[string]interface{}) {
@@ -56,11 +61,12 @@ func (t *Table) HasColumns(args ...string) bool {
 }
 
 func (f fizzer) CreateTable() interface{} {
-	return func(name string, fn func(t *Table), options map[string]interface{}) {
+	return func(name string, fn func(t *Table)) {
 		t := Table{
 			Name:    name,
 			Columns: []Column{},
 		}
+
 		fn(&t)
 		var foundPrimary bool
 		for _, c := range t.Columns {
@@ -74,8 +80,8 @@ func (f fizzer) CreateTable() interface{} {
 			t.Columns = append([]Column{INT_ID_COL}, t.Columns...)
 		}
 
-		if value, exists := options["timestamps"]; !exists || true == value {
-			t.Columns = append(t.Columns, CREATED_COL, UPDATED_COL)
+		if enabled, exists := t.Options["timestamps"]; !exists || enabled == true {
+			t.Timestamps()
 		}
 
 		f.add(f.Bubbler.CreateTable(t))

--- a/fizz/tables.go
+++ b/fizz/tables.go
@@ -20,6 +20,20 @@ func (t *Table) Column(name string, colType string, options map[string]interface
 	t.Columns = append(t.Columns, c)
 }
 
+func (t *Table) Timestamp(name string) {
+	c := Column{
+		Name:    name,
+		ColType: "timestamp",
+		Options: Options{},
+	}
+
+	t.Columns = append(t.Columns, c)
+}
+
+func (t *Table) Timestamps() {
+	t.Columns = append(t.Columns, []Column{CREATED_COL, UPDATED_COL}...)
+}
+
 func (t *Table) ColumnNames() []string {
 	cols := make([]string, len(t.Columns))
 	for i, c := range t.Columns {

--- a/fizz/translators/mysql_test.go
+++ b/fizz/translators/mysql_test.go
@@ -41,14 +41,14 @@ CREATE UNIQUE INDEX version_idx ON schema_migrations (version);`
 func (p *MySQLSuite) Test_MySQL_CreateTable() {
 	r := p.Require()
 	ddl := `CREATE TABLE users (
-created_at DATETIME NOT NULL,
-updated_at DATETIME NOT NULL,
+id integer NOT NULL AUTO_INCREMENT,
 first_name VARCHAR (255) NOT NULL,
 last_name VARCHAR (255) NOT NULL,
 email VARCHAR (20) NOT NULL,
 permissions text,
 age integer DEFAULT 40,
-id integer NOT NULL AUTO_INCREMENT,
+created_at DATETIME NOT NULL,
+updated_at DATETIME NOT NULL,
 PRIMARY KEY(id)
 ) ENGINE=InnoDB;`
 
@@ -67,8 +67,6 @@ PRIMARY KEY(id)
 func (p *MySQLSuite) Test_MySQL_CreateTable_UUID() {
 	r := p.Require()
 	ddl := `CREATE TABLE users (
-created_at DATETIME NOT NULL,
-updated_at DATETIME NOT NULL,
 first_name VARCHAR (255) NOT NULL,
 last_name VARCHAR (255) NOT NULL,
 email VARCHAR (20) NOT NULL,
@@ -76,6 +74,8 @@ permissions text,
 age integer DEFAULT 40,
 company_id char(36) NOT NULL DEFAULT 'test',
 uuid char(36) NOT NULL,
+created_at DATETIME NOT NULL,
+updated_at DATETIME NOT NULL,
 PRIMARY KEY(uuid)
 ) ENGINE=InnoDB;`
 

--- a/fizz/translators/postgres_test.go
+++ b/fizz/translators/postgres_test.go
@@ -11,15 +11,15 @@ var pgt = translators.NewPostgres()
 func (p *PostgreSQLSuite) Test_Postgres_CreateTable() {
 	r := p.Require()
 	ddl := `CREATE TABLE "users" (
-"created_at" timestamp NOT NULL,
-"updated_at" timestamp NOT NULL,
+"id" SERIAL PRIMARY KEY,
 "first_name" VARCHAR (255) NOT NULL,
 "last_name" VARCHAR (255) NOT NULL,
 "email" VARCHAR (20) NOT NULL,
 "permissions" jsonb,
 "age" integer DEFAULT '40',
 "company_id" UUID NOT NULL DEFAULT uuid_generate_v1(),
-"id" SERIAL PRIMARY KEY
+"created_at" timestamp NOT NULL,
+"updated_at" timestamp NOT NULL
 );`
 
 	res, _ := fizz.AString(`
@@ -38,14 +38,14 @@ func (p *PostgreSQLSuite) Test_Postgres_CreateTable() {
 func (p *PostgreSQLSuite) Test_Postgres_CreateTable_UUID() {
 	r := p.Require()
 	ddl := `CREATE TABLE "users" (
-"created_at" timestamp NOT NULL,
-"updated_at" timestamp NOT NULL,
 "first_name" VARCHAR (255) NOT NULL,
 "last_name" VARCHAR (255) NOT NULL,
 "email" VARCHAR (20) NOT NULL,
 "permissions" jsonb,
 "age" integer DEFAULT '40',
-"uuid" UUID PRIMARY KEY
+"uuid" UUID PRIMARY KEY,
+"created_at" timestamp NOT NULL,
+"updated_at" timestamp NOT NULL
 );`
 
 	res, _ := fizz.AString(`

--- a/fizz/translators/sqlite_test.go
+++ b/fizz/translators/sqlite_test.go
@@ -29,14 +29,14 @@ func (p *fauxSchema) TableInfo(table string) (*fizz.Table, error) {
 func (p *SQLiteSuite) Test_SQLite_CreateTable() {
 	r := p.Require()
 	ddl := `CREATE TABLE "users" (
-"created_at" DATETIME NOT NULL,
-"updated_at" DATETIME NOT NULL,
+"id" INTEGER PRIMARY KEY AUTOINCREMENT,
 "first_name" TEXT NOT NULL,
 "last_name" TEXT NOT NULL,
 "email" TEXT NOT NULL,
 "permissions" text,
 "age" integer DEFAULT '40',
-"id" INTEGER PRIMARY KEY AUTOINCREMENT
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
 );`
 
 	res, _ := fizz.AString(`
@@ -54,15 +54,15 @@ func (p *SQLiteSuite) Test_SQLite_CreateTable() {
 func (p *SQLiteSuite) Test_SQLite_CreateTable_UUID() {
 	r := p.Require()
 	ddl := `CREATE TABLE "users" (
-"created_at" DATETIME NOT NULL,
-"updated_at" DATETIME NOT NULL,
 "first_name" TEXT NOT NULL,
 "last_name" TEXT NOT NULL,
 "email" TEXT NOT NULL,
 "permissions" text,
 "age" integer DEFAULT '40',
 "company_id" char(36) NOT NULL DEFAULT lower(hex(randomblob(16))),
-"uuid" TEXT PRIMARY KEY
+"uuid" TEXT PRIMARY KEY,
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
 );`
 
 	res, _ := fizz.AString(`


### PR DESCRIPTION
1. Prepend primary key
2. Append timestamps (optionally timestamps can be disabled)
3. add useful Timestamps methods