### PR TITLE
Make timestamp to match MySQL's timestamp type.

### DIFF
--- a/fizz/translators/mysql.go
+++ b/fizz/translators/mysql.go
@@ -169,7 +169,9 @@ func (p *MySQL) colType(c fizz.Column) string {
 		return fmt.Sprintf("VARCHAR (%s)", s)
 	case "uuid":
 		return "char(36)"
-	case "timestamp", "time", "datetime":
+	case "timestamp":
+		return "TIMESTAMP"
+	case "time", "datetime":
 		return "DATETIME"
 	default:
 		return c.ColType

--- a/fizz/translators/mysql_test.go
+++ b/fizz/translators/mysql_test.go
@@ -74,6 +74,8 @@ permissions text,
 age integer DEFAULT 40,
 company_id char(36) NOT NULL DEFAULT 'test',
 uuid char(36) NOT NULL,
+deleted_at TIMESTAMP NOT NULL,
+expired_at DATETIME NOT NULL,
 created_at DATETIME NOT NULL,
 updated_at DATETIME NOT NULL,
 PRIMARY KEY(uuid)
@@ -88,6 +90,8 @@ PRIMARY KEY(uuid)
 		t.Column("age", "integer", {"null": true, "default": 40})
 		t.Column("company_id", "uuid", {"default_raw": "'test'"})
 		t.Column("uuid", "uuid", {"primary": true})
+		t.Column("deleted_at", "timestamp")
+		t.Column("expired_at", "datetime")
 	})
 	`, myt)
 	r.Equal(ddl, res)


### PR DESCRIPTION
It's very confusing that timestamp is translated to datetime when MySQL
has a type called timestamp.

This change uses the right type for timestamps in MySQL.

Signed-off-by: David Calavera <david.calavera@gmail.com>