### PR TITLE
Export Tx

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -20,7 +20,7 @@ type Connection struct {
 	Store   store
 	Dialect dialect
 	Elapsed int64
-	TX      *tX
+	TX      *Tx
 }
 
 func (c *Connection) String() string {

--- a/db.go
+++ b/db.go
@@ -6,7 +6,7 @@ type dB struct {
 	*sqlx.DB
 }
 
-func (db *dB) Transaction() (*tX, error) {
+func (db *dB) Transaction() (*Tx, error) {
 	return newTX(db)
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "3306:3306"
   postgres:
-    image: postgres
+    image: postgres:9.6
     environment:
       - POSTGRES_DB=pop_test
     ports:

--- a/store.go
+++ b/store.go
@@ -14,7 +14,7 @@ type store interface {
 	NamedExec(string, interface{}) (sql.Result, error)
 	Exec(string, ...interface{}) (sql.Result, error)
 	PrepareNamed(string) (*sqlx.NamedStmt, error)
-	Transaction() (*tX, error)
+	Transaction() (*Tx, error)
 	Rollback() error
 	Commit() error
 	Close() error

--- a/tx.go
+++ b/tx.go
@@ -12,13 +12,13 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-type tX struct {
+type Tx struct {
 	ID int
 	*sqlx.Tx
 }
 
-func newTX(db *dB) (*tX, error) {
-	t := &tX{
+func newTX(db *dB) (*Tx, error) {
+	t := &Tx{
 		ID: rand.Int(),
 	}
 	tx, err := db.Beginx()
@@ -28,10 +28,10 @@ func newTX(db *dB) (*tX, error) {
 
 // Transaction simply returns the current transaction,
 // this is defined so it implements the `Store` interface.
-func (tx *tX) Transaction() (*tX, error) {
+func (tx *Tx) Transaction() (*Tx, error) {
 	return tx, nil
 }
 
-func (tx *tX) Close() error {
+func (tx *Tx) Close() error {
 	return nil
 }


### PR DESCRIPTION
This enables users to define their own store as long as it implements the interface.

This helps resolve issues with using context, because if you define your own implementation of the store interface and swap it out, you can run queries with context.

(I pinned the postgres version because docker compose pulled down the latest and it caused a version mismatch with pg_dump.)