### PR TITLE
Fixed sqlite not migrating properly in various situations(rename index not working)

### DIFF
--- a/fizz/translators/schema.go
+++ b/fizz/translators/schema.go
@@ -14,6 +14,7 @@ type SchemaQuery interface {
 	ColumnInfo(table string, column string) (*fizz.Column, error)
 	IndexInfo(table string, idx string) (*fizz.Index, error)
 	Delete(string)
+	SetTable(*fizz.Table)
 }
 
 type Schema struct {
@@ -84,6 +85,10 @@ func (s *Schema) IndexInfo(table string, idx string) (*fizz.Index, error) {
 
 func (s *Schema) Delete(table string) {
 	delete(s.schema, table)
+}
+
+func (s *Schema) SetTable(table *fizz.Table) {
+	s.schema[table.Name] = table
 }
 
 func (s *Schema) findColumnInfo(tableInfo *fizz.Table, column string) (*fizz.Column, bool) {

--- a/fizz/translators/sqlite_test.go
+++ b/fizz/translators/sqlite_test.go
@@ -31,6 +31,10 @@ func (p *fauxSchema) Delete(table string) {
 	delete(p.schema, table)
 }
 
+func (s *fauxSchema) SetTable(table *fizz.Table) {
+	s.schema[table.Name] = table
+}
+
 func (p *fauxSchema) TableInfo(table string) (*fizz.Table, error) {
 	if ti, ok := p.schema[table]; ok {
 		return ti, nil
@@ -203,6 +207,16 @@ DROP TABLE "_users_tmp";`
 
 func (p *SQLiteSuite) Test_SQLite_AddIndex() {
 	r := p.Require()
+
+	schema.schema["table_name"] = &fizz.Table{
+		Name: "table_name",
+		Columns: []fizz.Column{
+			fizz.Column{
+				Name: "column_name",
+			},
+		},
+	}
+
 	ddl := `CREATE INDEX "table_name_column_name_idx" ON "table_name" (column_name);`
 
 	res, _ := fizz.AString(`add_index("table_name", "column_name", {})`, sqt)
@@ -235,6 +249,16 @@ func (p *SQLiteSuite) Test_SQLite_AddIndex_CustomName() {
 
 func (p *SQLiteSuite) Test_SQLite_DropIndex() {
 	r := p.Require()
+
+	schema.schema["my_table"] = &fizz.Table{
+		Name: "my_table",
+		Indexes: []fizz.Index{
+			fizz.Index{
+				Name: "my_idx",
+			},
+		},
+	}
+
 	ddl := `DROP INDEX IF EXISTS "my_idx";`
 
 	res, _ := fizz.AString(`drop_index("my_table", "my_idx")`, sqt)

--- a/migrations/20160808213310_setup_tests2.up.fizz
+++ b/migrations/20160808213310_setup_tests2.up.fizz
@@ -13,5 +13,5 @@ create_table("cakes", func(t) {
 
 add_column("books", "description", "string", {"default": ""})
 change_column("books", "description", "string", {"default": "test", "size": 100})
-#add_index("books","description",{})
-#rename_index("books","books_description_idx","books_description_index")
+add_index("books","description",{})
+rename_index("books","books_description_idx","books_description_index")

--- a/migrations/20160808213310_setup_tests2.up.fizz
+++ b/migrations/20160808213310_setup_tests2.up.fizz
@@ -13,3 +13,5 @@ create_table("cakes", func(t) {
 
 add_column("books", "description", "string", {"default": ""})
 change_column("books", "description", "string", {"default": "test", "size": 100})
+#add_index("books","description",{})
+#rename_index("books","books_description_idx","books_description_index")


### PR DESCRIPTION
I originally set out just to fix the rename_index, but found that the fix for it needed a bit more. Added another function to the Schema query system to set a table to make table create easier to cache. Then made sure that all the index changes in sqlite reflected in the schema cache should be more reliable now!

NOTE: the index functions in the test migration are commented out because after I fixed sqlite apparently MySQL wasn't working properly with them either... at least with the version of MySQL that loads for the testing and I don't know enough about MySQL nor have enough time to dig into it at the moment and figure out why.

As always happy to make any needed changes!