### PR TITLE
Using BelongsTo function with an alias to owner table.

### DIFF
--- a/belongs_to.go
+++ b/belongs_to.go
@@ -8,10 +8,25 @@ func (c *Connection) BelongsTo(model interface{}) *Query {
 	return Q(c).BelongsTo(model)
 }
 
+// BelongsToAs adds a "where" clause based on the "ID" of the
+// "model" passed into it using an alias.
+func (c *Connection) BelongsToAs(model interface{}, as string) *Query {
+	return Q(c).BelongsToAs(model, as)
+}
+
 // BelongsTo adds a "where" clause based on the "ID" of the
 // "model" passed into it.
 func (q *Query) BelongsTo(model interface{}) *Query {
 	m := &Model{Value: model}
+	q.Where(fmt.Sprintf("%s = ?", m.associationName()), m.ID())
+	return q
+}
+
+// BelongsToAs adds a "where" clause based on the "ID" of the
+// "model" passed into it, using an alias.
+func (q *Query) BelongsToAs(model interface{}, as string) *Query {
+	m := &Model{Value: model}
+	m.tableName = as
 	q.Where(fmt.Sprintf("%s = ?", m.associationName()), m.ID())
 	return q
 }

--- a/belongs_to.go
+++ b/belongs_to.go
@@ -26,8 +26,7 @@ func (q *Query) BelongsTo(model interface{}) *Query {
 // "model" passed into it, using an alias.
 func (q *Query) BelongsToAs(model interface{}, as string) *Query {
 	m := &Model{Value: model}
-	m.tableName = as
-	q.Where(fmt.Sprintf("%s = ?", m.associationName()), m.ID())
+	q.Where(fmt.Sprintf("%s = ?", as), m.ID())
 	return q
 }
 

--- a/belongs_to_test.go
+++ b/belongs_to_test.go
@@ -21,7 +21,7 @@ func Test_BelongsTo(t *testing.T) {
 func Test_BelongsToAs(t *testing.T) {
 	r := require.New(t)
 
-	q := PDB.BelongsToAs(&User{ID: 1}, "u")
+	q := PDB.BelongsToAs(&User{ID: 1}, "u_id")
 
 	m := &pop.Model{Value: &Enemy{}}
 

--- a/belongs_to_test.go
+++ b/belongs_to_test.go
@@ -18,6 +18,17 @@ func Test_BelongsTo(t *testing.T) {
 	r.Equal(ts("SELECT enemies.A FROM enemies AS enemies WHERE user_id = ?"), sql)
 }
 
+func Test_BelongsToAs(t *testing.T) {
+	r := require.New(t)
+
+	q := PDB.BelongsToAs(&User{ID: 1}, "u")
+
+	m := &pop.Model{Value: &Enemy{}}
+
+	sql, _ := q.ToSQL(m)
+	r.Equal(ts("SELECT enemies.A FROM enemies AS enemies WHERE u_id = ?"), sql)
+}
+
 func Test_BelongsToThrough(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
Hi @markbates, first of all I really want to thank you for all your effort and simplicity brought to this useful package. I've been using *Go buffalo* for a while and it seems to me pretty easy to use and very interesting. That's why I came here.

To expose the case I wanted to solve with this PR let's assume I have a table in a database called `users` which owns another table called `pets`, it is a one to many relationship.  In `pets` table 
there is a column that references `users` table primary key and is called `u_id`. 

In my project I have defined these structs for all tables previously mentioned .

```
type User struct {
    ID   uuid.UUID  `json:"id" db:"id"` 
}
```

```
type Pet struct {
    ID            uuid.UUID   `json:"id" db:"id"`
    UserID      uuid.UUID   `json:"userID" db:"u_id"`
}
```

As you see,  `UserID` is mapped to `u_id` column. When I tried to use `BelongsTo` function to load all pets that belong to a specific user, I found that `user_id` is used instead of `u_id` and the result is an empty slice.

This PR provides a solution to handle this situation. Let me know what do you think. 

