### PR TITLE
Adding float mappings

### DIFF
--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -262,7 +262,7 @@ func fizzColType(s string) string {
 		return "int[]"
 	case "slices.map":
 		return "jsonb"
-	case "float32", "float64":
+	case "float32", "float64", "float":
 		return "decimal"
 	default:
 		if nrx.MatchString(s) {

--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -237,6 +237,8 @@ func colType(s string) string {
 		return "slices.Int"
 	case "slices.float", "[]float", "[]float32", "[]float64":
 		return "slices.Float"
+	case "decimal":
+		return "float64"
 	default:
 		return s
 	}
@@ -260,6 +262,8 @@ func fizzColType(s string) string {
 		return "int[]"
 	case "slices.map":
 		return "jsonb"
+	case "float32", "float64", "float":
+		return "decimal"
 	default:
 		if nrx.MatchString(s) {
 			return fizzColType(strings.Replace(s, "nulls.", "", -1))

--- a/soda/cmd/generate/model.go
+++ b/soda/cmd/generate/model.go
@@ -237,7 +237,7 @@ func colType(s string) string {
 		return "slices.Int"
 	case "slices.float", "[]float", "[]float32", "[]float64":
 		return "slices.Float"
-	case "decimal":
+	case "decimal", "float":
 		return "float64"
 	default:
 		return s
@@ -262,7 +262,7 @@ func fizzColType(s string) string {
 		return "int[]"
 	case "slices.map":
 		return "jsonb"
-	case "float32", "float64", "float":
+	case "float32", "float64":
 		return "decimal"
 	default:
 		if nrx.MatchString(s) {


### PR DESCRIPTION
This PR solves a common problem we've been having at Wawandco, when generating models with Buffalo that contain float attributes Pop was not adding the correct types on the database, meaning after generating:

```sh
buffalo g r cars color price:float
buffalo g r cars color price:float64
buffalo g r cars color price:float32
```

We ended with a fizz migration that looked like:

```
create_table("cars", func(t) {
	t.Column("id", "uuid", {"primary": true})
	t.Column("color", "string", {})
	t.Column("price", "float", {})
})
```

Causing that migration break when running, the same happened when using `decimal` as the type of the field.

I added here mappings for floats (float32, float64, float) as well as `decimal` column type mapping to `float64` on generated struct.