### PR TITLE
Should fix weirdness with exec.Command and space

### DIFF
--- a/cockroach.go
+++ b/cockroach.go
@@ -199,7 +199,7 @@ func (p *cockroach) LoadSchema(r io.Reader) error {
 		secure = "--insecure"
 	}
 
-	cmd := exec.Command("cockroach", "sql", secure, fmt.Sprintf("--database=%s --user=%s", p.Details().Database, p.Details().User))
+	cmd := exec.Command("cockroach", "sql", secure, fmt.Sprintf("--database=%s", p.Details().Database), fmt.Sprintf("--user=%s", p.Details().User))
 	in, err := cmd.StdinPipe()
 	if err != nil {
 		return err


### PR DESCRIPTION
Thought that would have worked, but apparently exec.Command did something I didn't expect...