### PR TITLE
WIP: Eager Association creation 

### DIFF
--- a/associations/association.go
+++ b/associations/association.go
@@ -25,6 +25,19 @@ type AssociationSortable interface {
 	Association
 }
 
+// AssociationCreatableStatement a association that stablish
+// some statements on create.
+type AssociationCreatableStatement interface {
+	Statements() []AssociationStatement
+}
+
+// AssociationStatement a type that represents a statement to be
+// executed.
+type AssociationStatement struct {
+	Statement string
+	Args      []interface{}
+}
+
 // Associations a group of model associations.
 type Associations []Association
 

--- a/associations/association.go
+++ b/associations/association.go
@@ -14,7 +14,9 @@ type Association interface {
 	Kind() reflect.Kind
 	Interface() interface{}
 	Constraint() (string, []interface{})
-	SetValue(interface{}) error
+	Dependencies() []interface{}
+	SetValue([]interface{}) error
+	Skipped() bool
 }
 
 // AssociationSortable a type to be sortable.
@@ -25,10 +27,6 @@ type AssociationSortable interface {
 
 // Associations a group of model associations.
 type Associations []Association
-
-// SkippedAssociation an empty association used to indicate
-// an association should not be queried.
-var SkippedAssociation = (Association)(nil)
 
 // associationParams a wrapper for associations definition
 // and creation.
@@ -52,4 +50,9 @@ func fieldIsNil(f reflect.Value) bool {
 		return n.Interface() == nil
 	}
 	return f.Interface() == nil
+}
+
+func isZero(i interface{}) bool {
+	v := reflect.ValueOf(i)
+	return v.Interface() == reflect.Zero(v.Type()).Interface()
 }

--- a/associations/belongs_to_association.go
+++ b/associations/belongs_to_association.go
@@ -63,3 +63,7 @@ func (b *belongsToAssociation) Interface() interface{} {
 func (b *belongsToAssociation) Constraint() (string, []interface{}) {
 	return "id = ?", []interface{}{b.ownerID.Interface()}
 }
+
+func (b *belongsToAssociation) SetValue(i interface{}) error {
+	return nil
+}

--- a/associations/belongs_to_association.go
+++ b/associations/belongs_to_association.go
@@ -91,11 +91,9 @@ func (b *belongsToAssociation) SetValue(i []interface{}) error {
 		} else {
 			b.ownerID.Set(reflect.ValueOf(ownerID))
 		}
-	} else {
-		return fmt.Errorf("could not set '%s' to '%s'", ownerID, b.ownerID)
+		return nil
 	}
-
-	return nil
+	return fmt.Errorf("could not set '%s' to '%s'", ownerID, b.ownerID)
 }
 
 func (b *belongsToAssociation) Skipped() bool {

--- a/associations/has_many_association_test.go
+++ b/associations/has_many_association_test.go
@@ -46,6 +46,6 @@ func Test_Has_Many_SetValue(t *testing.T) {
 	as, _ := associations.AssociationsForStruct(&foo)
 
 	a.Equal(len(as), 1)
-	as[0].SetValue(foo.ID)
+	as[0].SetValue([]interface{}{foo.ID})
 	a.Equal(foo.ID, (*foo.BarHasManies)[0].FooHasManyID.Interface().(int))
 }

--- a/associations/has_one_association.go
+++ b/associations/has_one_association.go
@@ -62,3 +62,7 @@ func (h *hasOneAssociation) Constraint() (string, []interface{}) {
 
 	return condition, []interface{}{h.ownerID}
 }
+
+func (h *hasOneAssociation) SetValue(i interface{}) error {
+	return nil
+}

--- a/associations/has_one_association.go
+++ b/associations/has_one_association.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/markbates/inflect"
+	"github.com/markbates/pop/nulls"
 )
 
 type hasOneAssociation struct {
@@ -64,5 +65,15 @@ func (h *hasOneAssociation) Constraint() (string, []interface{}) {
 }
 
 func (h *hasOneAssociation) SetValue(i interface{}) error {
+	fval := h.ownedModel.FieldByName(h.ownerName + "ID")
+	if fval.CanSet() {
+		if n := nulls.New(fval.Interface()); n != nil {
+			fval.Set(reflect.ValueOf(n.Parse(i)))
+		} else {
+			fval.Set(reflect.ValueOf(i))
+		}
+	} else {
+		return fmt.Errorf("could not set '%s' to '%s'", i, fval)
+	}
 	return nil
 }

--- a/associations/has_one_association.go
+++ b/associations/has_one_association.go
@@ -92,10 +92,10 @@ func (h *hasOneAssociation) SetValue(i []interface{}) error {
 		} else {
 			fval.Set(reflect.ValueOf(ownerID))
 		}
-	} else {
-		return fmt.Errorf("could not set '%s' to '%s'", ownerID, fval)
+		return nil
 	}
-	return nil
+
+	return fmt.Errorf("could not set '%s' to '%s'", ownerID, fval)
 }
 
 func (h *hasOneAssociation) Skipped() bool {

--- a/associations/has_one_association_test.go
+++ b/associations/has_one_association_test.go
@@ -45,6 +45,6 @@ func Test_Has_One_SetValue(t *testing.T) {
 	as, _ := associations.AssociationsForStruct(&foo)
 	a.Equal(len(as), 1)
 
-	as[0].SetValue(foo.ID)
+	as[0].SetValue([]interface{}{foo.ID})
 	a.Equal(foo.ID, foo.BarHasOne.FooHasOneID.Interface().(uuid.UUID))
 }

--- a/associations/many_to_many_association.go
+++ b/associations/many_to_many_association.go
@@ -15,14 +15,16 @@ type manyToManyAssociation struct {
 	owner               interface{}
 	fkID                string
 	orderBy             string
+	skipped             bool
 }
 
 func init() {
 	associationBuilders["many_to_many"] = func(p associationParams) (Association, error) {
 		// Validates if model.ID is nil, this association will be skipped.
+		var skipped bool
 		model := p.modelValue
 		if fieldIsNil(model.FieldByName("ID")) {
-			return SkippedAssociation, nil
+			skipped = true
 		}
 
 		return &manyToManyAssociation{
@@ -33,6 +35,7 @@ func init() {
 			manyToManyTableName: p.popTags.Find("many_to_many").Value,
 			fkID:                p.popTags.Find("fk_id").Value,
 			orderBy:             p.popTags.Find("order_by").Value,
+			skipped:             skipped,
 		}, nil
 	}
 }
@@ -78,6 +81,14 @@ func (m *manyToManyAssociation) OrderBy() string {
 	return m.orderBy
 }
 
-func (m *manyToManyAssociation) SetValue(i interface{}) error {
+func (m *manyToManyAssociation) Dependencies() []interface{} {
 	return nil
+}
+
+func (m *manyToManyAssociation) SetValue(i []interface{}) error {
+	return nil
+}
+
+func (m *manyToManyAssociation) Skipped() bool {
+	return m.skipped
 }

--- a/associations/many_to_many_association.go
+++ b/associations/many_to_many_association.go
@@ -77,3 +77,7 @@ func (m *manyToManyAssociation) Constraint() (string, []interface{}) {
 func (m *manyToManyAssociation) OrderBy() string {
 	return m.orderBy
 }
+
+func (m *manyToManyAssociation) SetValue(i interface{}) error {
+	return nil
+}

--- a/connection.go
+++ b/connection.go
@@ -16,11 +16,13 @@ var Connections = map[string]*Connection{}
 // Connection represents all of the necessary details for
 // talking with a datastore
 type Connection struct {
-	ID      string
-	Store   store
-	Dialect dialect
-	Elapsed int64
-	TX      *Tx
+	ID          string
+	Store       store
+	Dialect     dialect
+	Elapsed     int64
+	TX          *Tx
+	eager       bool
+	eagerFields []string
 }
 
 func (c *Connection) String() string {

--- a/executors.go
+++ b/executors.go
@@ -2,6 +2,7 @@ package pop
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/markbates/pop/columns"
 	"github.com/markbates/validate"
@@ -10,6 +11,22 @@ import (
 
 // Reload fetch fresh data for a given model, using its ID
 func (c *Connection) Reload(model interface{}) error {
+	v := reflect.Indirect(reflect.ValueOf(model))
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		var err error
+		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i)
+			if val.Kind() != reflect.Ptr {
+				val = val.Addr()
+			}
+			err = c.Reload(val.Interface())
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+
 	sm := Model{Value: model}
 	return c.Find(model, sm.ID())
 }
@@ -42,6 +59,25 @@ func (q *Query) ExecWithCount() (int, error) {
 // ValidateAndSave applies validation rules on the given entry, then save it
 // if the validation succeed, excluding the given columns.
 func (c *Connection) ValidateAndSave(model interface{}, excludeColumns ...string) (*validate.Errors, error) {
+	v := reflect.Indirect(reflect.ValueOf(model))
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		var err error
+		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i)
+			if val.Kind() != reflect.Ptr {
+				val = val.Addr()
+			}
+			verrs, err := c.ValidateAndSave(val.Interface(), excludeColumns...)
+			if err != nil {
+				return verrs, err
+			}
+			if verrs.HasAny() {
+				return verrs, nil
+			}
+		}
+		return validate.NewErrors(), err
+	}
+
 	sm := &Model{Value: model}
 	verrs, err := sm.validateSave(c)
 	if err != nil {
@@ -58,6 +94,22 @@ var emptyUUID = uuid.Nil.String()
 // Save wraps the Create and Update methods. It executes a Create if no ID is provided with the entry;
 // or issues an Update otherwise.
 func (c *Connection) Save(model interface{}, excludeColumns ...string) error {
+	v := reflect.Indirect(reflect.ValueOf(model))
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		var err error
+		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i)
+			if val.Kind() != reflect.Ptr {
+				val = val.Addr()
+			}
+			err = c.Save(val.Interface(), excludeColumns...)
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+
 	sm := &Model{Value: model}
 	id := sm.ID()
 
@@ -70,6 +122,25 @@ func (c *Connection) Save(model interface{}, excludeColumns ...string) error {
 // ValidateAndCreate applies validation rules on the given entry, then creates it
 // if the validation succeed, excluding the given columns.
 func (c *Connection) ValidateAndCreate(model interface{}, excludeColumns ...string) (*validate.Errors, error) {
+	v := reflect.Indirect(reflect.ValueOf(model))
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		var err error
+		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i)
+			if val.Kind() != reflect.Ptr {
+				val = val.Addr()
+			}
+			verrs, err := c.ValidateAndCreate(val.Interface(), excludeColumns...)
+			if err != nil {
+				return verrs, err
+			}
+			if verrs.HasAny() {
+				return verrs, nil
+			}
+		}
+		return validate.NewErrors(), err
+	}
+
 	sm := &Model{Value: model}
 	verrs, err := sm.validateCreate(c)
 	if err != nil {
@@ -84,6 +155,22 @@ func (c *Connection) ValidateAndCreate(model interface{}, excludeColumns ...stri
 // Create add a new given entry to the database, excluding the given columns.
 // It updates `created_at` and `updated_at` columns automatically.
 func (c *Connection) Create(model interface{}, excludeColumns ...string) error {
+	v := reflect.Indirect(reflect.ValueOf(model))
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		var err error
+		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i)
+			if val.Kind() != reflect.Ptr {
+				val = val.Addr()
+			}
+			err = c.Create(val.Interface(), excludeColumns...)
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+
 	return c.timeFunc("Create", func() error {
 		var err error
 		sm := &Model{Value: model}
@@ -117,6 +204,25 @@ func (c *Connection) Create(model interface{}, excludeColumns ...string) error {
 // ValidateAndUpdate applies validation rules on the given entry, then update it
 // if the validation succeed, excluding the given columns.
 func (c *Connection) ValidateAndUpdate(model interface{}, excludeColumns ...string) (*validate.Errors, error) {
+	v := reflect.Indirect(reflect.ValueOf(model))
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		var err error
+		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i)
+			if val.Kind() != reflect.Ptr {
+				val = val.Addr()
+			}
+			verrs, err := c.ValidateAndUpdate(val.Interface(), excludeColumns...)
+			if err != nil {
+				return verrs, err
+			}
+			if verrs.HasAny() {
+				return verrs, nil
+			}
+		}
+		return validate.NewErrors(), err
+	}
+
 	sm := &Model{Value: model}
 	verrs, err := sm.validateUpdate(c)
 	if err != nil {
@@ -131,6 +237,22 @@ func (c *Connection) ValidateAndUpdate(model interface{}, excludeColumns ...stri
 // Update writes changes from an entry to the database, excluding the given columns.
 // It updates the `updated_at` column automatically.
 func (c *Connection) Update(model interface{}, excludeColumns ...string) error {
+	v := reflect.Indirect(reflect.ValueOf(model))
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		var err error
+		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i)
+			if val.Kind() != reflect.Ptr {
+				val = val.Addr()
+			}
+			err = c.Update(val.Interface(), excludeColumns...)
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+
 	return c.timeFunc("Update", func() error {
 		var err error
 		sm := &Model{Value: model}
@@ -161,6 +283,22 @@ func (c *Connection) Update(model interface{}, excludeColumns ...string) error {
 
 // Destroy deletes a given entry from the database
 func (c *Connection) Destroy(model interface{}) error {
+	v := reflect.Indirect(reflect.ValueOf(model))
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		var err error
+		for i := 0; i < v.Len(); i++ {
+			val := v.Index(i)
+			if val.Kind() != reflect.Ptr {
+				val = val.Addr()
+			}
+			err = c.Destroy(val.Interface())
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+
 	return c.timeFunc("Destroy", func() error {
 		var err error
 		sm := &Model{Value: model}

--- a/executors.go
+++ b/executors.go
@@ -195,6 +195,18 @@ func (c *Connection) Create(model interface{}, excludeColumns ...string) error {
 
 		// set values based on dependencies.
 		a.SetValue(dependencies)
+
+		if acs, ok := a.(associations.AssociationCreatableStatement); ok {
+			stms := acs.Statements()
+			for _, stm := range stms {
+				_, err = c.TX.Exec(stm.Statement, stm.Args...)
+				if err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
 		err = c.Create(a.Interface())
 		if err != nil {
 			return err

--- a/executors_test.go
+++ b/executors_test.go
@@ -355,6 +355,35 @@ func Test_Create_With_Slice(t *testing.T) {
 	})
 }
 
+func Test_Eager_Create(t *testing.T) {
+	transaction(func(tx *pop.Connection) {
+		a := require.New(t)
+
+		count, _ := tx.Count(&User{})
+		user := User{
+			Name:  nulls.NewString("Mark 'Awesome' Bates"),
+			Books: Books{{Title: "Pop Book", Description: "Pop Book", Isbn: "PB1"}},
+		}
+
+		err := tx.Eager().Create(&user)
+		a.NoError(err)
+		a.NotEqual(user.ID, 0)
+
+		ctx, _ := tx.Count(&User{})
+		a.Equal(count+1, ctx)
+
+		ctx, _ = tx.Count(&Book{})
+		a.Equal(count+1, ctx)
+
+		u := User{}
+		q := tx.Eager().Where("name = ?", "Mark 'Awesome' Bates")
+		err = q.First(&u)
+		a.NoError(err)
+		a.Equal(user.Name.String, "Mark 'Awesome' Bates")
+		a.Equal(user.Books[0].Title, "Pop Book")
+	})
+}
+
 func Test_Create_UUID(t *testing.T) {
 	transaction(func(tx *pop.Connection) {
 		a := require.New(t)

--- a/executors_test.go
+++ b/executors_test.go
@@ -356,7 +356,6 @@ func Test_Create_With_Slice(t *testing.T) {
 }
 
 // TODO: Ignore those zero value association so they can not be created in database.
-// TODO: many_to_many associations.(NI)
 func Test_Eager_Create_Has_Many(t *testing.T) {
 	transaction(func(tx *pop.Connection) {
 		a := require.New(t)
@@ -365,6 +364,9 @@ func Test_Eager_Create_Has_Many(t *testing.T) {
 			Name:         nulls.NewString("Mark 'Awesome' Bates"),
 			Books:        Books{{Title: "Pop Book", Description: "Pop Book", Isbn: "PB1"}},
 			FavoriteSong: Song{Title: "Hook - Blues Traveler"},
+			Houses: Addresses{
+				Address{HouseNumber: 86, Street: "Modelo"},
+			},
 		}
 
 		err := tx.Eager().Create(&user)
@@ -380,6 +382,9 @@ func Test_Eager_Create_Has_Many(t *testing.T) {
 		ctx, _ = tx.Count(&Song{})
 		a.Equal(count+1, ctx)
 
+		ctx, _ = tx.Count(&Address{})
+		a.Equal(count+1, ctx)
+
 		u := User{}
 		q := tx.Eager().Where("name = ?", "Mark 'Awesome' Bates")
 		err = q.First(&u)
@@ -387,6 +392,7 @@ func Test_Eager_Create_Has_Many(t *testing.T) {
 		a.Equal(u.Name.String, "Mark 'Awesome' Bates")
 		a.Equal(u.Books[0].Title, "Pop Book")
 		a.Equal(u.FavoriteSong.Title, "Hook - Blues Traveler")
+		a.Equal(u.Houses[0].Street, "Modelo")
 	})
 }
 

--- a/executors_test.go
+++ b/executors_test.go
@@ -40,6 +40,49 @@ func Test_ValidateAndSave(t *testing.T) {
 	})
 }
 
+func Test_ValidateAndSave_With_Slice(t *testing.T) {
+	r := require.New(t)
+	validationLogs = []string{}
+	transaction(func(tx *pop.Connection) {
+		car := []ValidatableCar{
+			{Name: "VW"},
+			{Name: "AU"},
+		}
+		verrs, err := tx.ValidateAndSave(&car)
+		r.NoError(err)
+		r.False(verrs.HasAny())
+		r.Len(validationLogs, 4)
+		r.Equal([]string{"Validate", "ValidateSave", "Validate", "ValidateSave"}, validationLogs)
+
+		r.NotZero(car[0].ID)
+		r.NotZero(car[0].CreatedAt)
+		r.NotZero(car[1].ID)
+		r.NotZero(car[1].CreatedAt)
+
+		validationLogs = []string{}
+		car = []ValidatableCar{
+			{Name: ""},
+			{Name: "AU"},
+		}
+		verrs, err = tx.ValidateAndSave(&car)
+		r.NoError(err)
+		r.True(verrs.HasAny())
+		r.Len(validationLogs, 2)
+		errs := verrs.Get("name")
+		r.Len(errs, 1)
+
+		validationLogs = []string{}
+		ncar := []NotValidatableCar{
+			{Name: ""},
+			{Name: "AU"},
+		}
+		verrs, err = tx.ValidateAndSave(&ncar)
+		r.NoError(err)
+		r.False(verrs.HasAny())
+		r.Len(validationLogs, 0)
+	})
+}
+
 func Test_ValidateAndCreate(t *testing.T) {
 	r := require.New(t)
 	validationLogs = []string{}
@@ -64,6 +107,48 @@ func Test_ValidateAndCreate(t *testing.T) {
 
 		validationLogs = []string{}
 		ncar := &NotValidatableCar{Name: ""}
+		verrs, err = tx.ValidateAndCreate(ncar)
+		r.NoError(err)
+		r.False(verrs.HasAny())
+		r.Len(validationLogs, 0)
+	})
+}
+
+func Test_ValidateAndCreate_With_Slice(t *testing.T) {
+	r := require.New(t)
+	validationLogs = []string{}
+	transaction(func(tx *pop.Connection) {
+		car := []ValidatableCar{
+			{Name: "VW"},
+			{Name: "AU"},
+		}
+		verrs, err := tx.ValidateAndCreate(&car)
+		r.NoError(err)
+		r.False(verrs.HasAny())
+		r.Len(validationLogs, 4)
+		r.Equal([]string{"Validate", "ValidateCreate", "Validate", "ValidateCreate"}, validationLogs)
+		r.NotZero(car[0].ID)
+		r.NotZero(car[0].CreatedAt)
+		r.NotZero(car[1].ID)
+		r.NotZero(car[1].CreatedAt)
+
+		validationLogs = []string{}
+		car = []ValidatableCar{
+			{Name: ""},
+			{Name: "AU"},
+		}
+		verrs, err = tx.ValidateAndSave(&car)
+		r.NoError(err)
+		r.True(verrs.HasAny())
+		r.Len(validationLogs, 2)
+		errs := verrs.Get("name")
+		r.Len(errs, 1)
+
+		validationLogs = []string{}
+		ncar := []NotValidatableCar{
+			{Name: ""},
+			{Name: "AU"},
+		}
 		verrs, err = tx.ValidateAndCreate(ncar)
 		r.NoError(err)
 		r.False(verrs.HasAny())
@@ -103,6 +188,52 @@ func Test_ValidateAndUpdate(t *testing.T) {
 		validationLogs = []string{}
 		ncar.Name = ""
 		verrs, err = tx.ValidateAndUpdate(ncar)
+		r.NoError(err)
+		r.False(verrs.HasAny())
+		r.Len(validationLogs, 0)
+	})
+}
+
+func Test_ValidateAndUpdate_With_Slice(t *testing.T) {
+	r := require.New(t)
+	validationLogs = []string{}
+	transaction(func(tx *pop.Connection) {
+		car := []ValidatableCar{
+			{Name: "VW"},
+			{Name: "AU"},
+		}
+		verrs, err := tx.ValidateAndCreate(&car)
+		r.NoError(err)
+		r.False(verrs.HasAny())
+		r.Len(validationLogs, 4)
+		r.Equal([]string{"Validate", "ValidateCreate", "Validate", "ValidateCreate"}, validationLogs)
+		r.NotZero(car[0].ID)
+		r.NotZero(car[0].CreatedAt)
+		r.NotZero(car[1].ID)
+		r.NotZero(car[1].CreatedAt)
+
+		validationLogs = []string{}
+		car[0].Name = ""
+		verrs, err = tx.ValidateAndUpdate(&car)
+		r.NoError(err)
+		r.True(verrs.HasAny())
+		r.Len(validationLogs, 2)
+		errs := verrs.Get("name")
+		r.Len(errs, 1)
+
+		validationLogs = []string{}
+		ncar := []NotValidatableCar{
+			{Name: ""},
+			{Name: "AU"},
+		}
+		verrs, err = tx.ValidateAndCreate(&ncar)
+		r.NoError(err)
+		r.False(verrs.HasAny())
+		r.Len(validationLogs, 0)
+
+		validationLogs = []string{}
+		ncar[1].Name = ""
+		verrs, err = tx.ValidateAndUpdate(&ncar)
 		r.NoError(err)
 		r.False(verrs.HasAny())
 		r.Len(validationLogs, 0)
@@ -164,6 +295,27 @@ func Test_Save(t *testing.T) {
 	})
 }
 
+func Test_Save_With_Slice(t *testing.T) {
+	r := require.New(t)
+	transaction(func(tx *pop.Connection) {
+		u := Users{
+			{Name: nulls.NewString("Mark")},
+			{Name: nulls.NewString("Larry")},
+		}
+		r.Zero(u[0].ID)
+		r.Zero(u[1].ID)
+
+		tx.Save(&u)
+		r.NotZero(u[0].ID)
+		r.NotZero(u[1].ID)
+
+		uat := u[0].UpdatedAt.UnixNano()
+
+		tx.Save(u)
+		r.NotEqual(uat, u[0].UpdatedAt.UnixNano())
+	})
+}
+
 func Test_Create(t *testing.T) {
 	transaction(func(tx *pop.Connection) {
 		a := require.New(t)
@@ -182,6 +334,24 @@ func Test_Create(t *testing.T) {
 		err = q.First(&u)
 		a.NoError(err)
 		a.Equal(user.Name.String, "Mark 'Awesome' Bates")
+	})
+}
+
+func Test_Create_With_Slice(t *testing.T) {
+	transaction(func(tx *pop.Connection) {
+		a := require.New(t)
+
+		count, _ := tx.Count(&User{})
+		users := Users{
+			{Name: nulls.NewString("Mark Bates")},
+			{Name: nulls.NewString("Larry M. Jordan")},
+			{Name: nulls.NewString("Pop")},
+		}
+		err := tx.Create(&users)
+		a.NoError(err)
+
+		ctx, _ := tx.Count(&User{})
+		a.Equal(count+3, ctx)
 	})
 }
 
@@ -267,6 +437,34 @@ func Test_Update(t *testing.T) {
 	})
 }
 
+func Test_Update_With_Slice(t *testing.T) {
+	transaction(func(tx *pop.Connection) {
+		a := require.New(t)
+
+		user := Users{
+			{Name: nulls.NewString("Mark")},
+			{Name: nulls.NewString("Larry")},
+		}
+		tx.Create(&user)
+
+		a.NotZero(user[0].CreatedAt)
+		a.NotZero(user[0].UpdatedAt)
+
+		a.NotZero(user[1].CreatedAt)
+		a.NotZero(user[1].UpdatedAt)
+
+		user[0].Name.String = "Marky"
+		user[1].Name.String = "Lawrence"
+
+		err := tx.Update(&user)
+		a.NoError(err)
+
+		tx.Reload(&user)
+		a.Equal(user[0].Name.String, "Marky")
+		a.Equal(user[1].Name.String, "Lawrence")
+	})
+}
+
 func Test_Update_UUID(t *testing.T) {
 	transaction(func(tx *pop.Connection) {
 		r := require.New(t)
@@ -300,6 +498,31 @@ func Test_Destroy(t *testing.T) {
 
 		ctx, err := tx.Count("users")
 		a.Equal(count+1, ctx)
+
+		err = tx.Destroy(&user)
+		a.NoError(err)
+
+		ctx, _ = tx.Count("users")
+		a.Equal(count, ctx)
+	})
+}
+
+func Test_Destroy_With_Slice(t *testing.T) {
+	transaction(func(tx *pop.Connection) {
+		a := require.New(t)
+
+		count, err := tx.Count("users")
+		user := Users{
+			{Name: nulls.NewString("Mark")},
+			{Name: nulls.NewString("Larry")},
+		}
+		err = tx.Create(&user)
+		a.NoError(err)
+		a.NotEqual(user[0].ID, 0)
+		a.NotEqual(user[1].ID, 0)
+
+		ctx, err := tx.Count("users")
+		a.Equal(count+2, ctx)
 
 		err = tx.Destroy(&user)
 		a.NoError(err)

--- a/executors_test.go
+++ b/executors_test.go
@@ -355,14 +355,18 @@ func Test_Create_With_Slice(t *testing.T) {
 	})
 }
 
+// TODO: Ignore those zero value association so they can not be created in database.
+// TODO: many_to_many associations.(NI)
+// TODO: belongs_to associations. (NI)
 func Test_Eager_Create(t *testing.T) {
 	transaction(func(tx *pop.Connection) {
 		a := require.New(t)
 
 		count, _ := tx.Count(&User{})
 		user := User{
-			Name:  nulls.NewString("Mark 'Awesome' Bates"),
-			Books: Books{{Title: "Pop Book", Description: "Pop Book", Isbn: "PB1"}},
+			Name:         nulls.NewString("Mark 'Awesome' Bates"),
+			Books:        Books{{Title: "Pop Book", Description: "Pop Book", Isbn: "PB1"}},
+			FavoriteSong: Song{Title: "Hook - Blues Traveler"},
 		}
 
 		err := tx.Eager().Create(&user)
@@ -375,12 +379,16 @@ func Test_Eager_Create(t *testing.T) {
 		ctx, _ = tx.Count(&Book{})
 		a.Equal(count+1, ctx)
 
+		ctx, _ = tx.Count(&Song{})
+		a.Equal(count+1, ctx)
+
 		u := User{}
 		q := tx.Eager().Where("name = ?", "Mark 'Awesome' Bates")
 		err = q.First(&u)
 		a.NoError(err)
-		a.Equal(user.Name.String, "Mark 'Awesome' Bates")
-		a.Equal(user.Books[0].Title, "Pop Book")
+		a.Equal(u.Name.String, "Mark 'Awesome' Bates")
+		a.Equal(u.Books[0].Title, "Pop Book")
+		a.Equal(u.FavoriteSong.Title, "Hook - Blues Traveler")
 	})
 }
 

--- a/executors_test.go
+++ b/executors_test.go
@@ -357,11 +357,9 @@ func Test_Create_With_Slice(t *testing.T) {
 
 // TODO: Ignore those zero value association so they can not be created in database.
 // TODO: many_to_many associations.(NI)
-// TODO: belongs_to associations. (NI)
-func Test_Eager_Create(t *testing.T) {
+func Test_Eager_Create_Has_Many(t *testing.T) {
 	transaction(func(tx *pop.Connection) {
 		a := require.New(t)
-
 		count, _ := tx.Count(&User{})
 		user := User{
 			Name:         nulls.NewString("Mark 'Awesome' Bates"),
@@ -389,6 +387,29 @@ func Test_Eager_Create(t *testing.T) {
 		a.Equal(u.Name.String, "Mark 'Awesome' Bates")
 		a.Equal(u.Books[0].Title, "Pop Book")
 		a.Equal(u.FavoriteSong.Title, "Hook - Blues Traveler")
+	})
+}
+
+func Test_Eager_Create_Belongs_To(t *testing.T) {
+	transaction(func(tx *pop.Connection) {
+		a := require.New(t)
+		book := Book{
+			Title:       "Pop Book",
+			Description: "Pop Book",
+			Isbn:        "PB1",
+			User: User{
+				Name: nulls.NewString("Larry"),
+			},
+		}
+
+		err := tx.Eager().Create(&book)
+		a.NoError(err)
+
+		ctx, _ := tx.Count(&Book{})
+		a.Equal(1, ctx)
+
+		ctx, _ = tx.Count(&User{})
+		a.Equal(1, ctx)
 	})
 }
 

--- a/finders.go
+++ b/finders.go
@@ -194,7 +194,7 @@ func (q *Query) eagerAssociations(model interface{}) error {
 	}
 
 	for _, association := range assos {
-		if association == associations.SkippedAssociation {
+		if association.Skipped() {
 			continue
 		}
 

--- a/finders.go
+++ b/finders.go
@@ -19,7 +19,10 @@ var rLimit = regexp.MustCompile("(?i)(limit [0-9]+)$")
 //
 //	c.Find(&User{}, 1)
 func (c *Connection) Find(model interface{}, id interface{}) error {
-	return Q(c).Find(model, id)
+	q := Q(c)
+	q.eager = c.eager
+	q.eagerFields = c.eagerFields
+	return q.Find(model, id)
 }
 
 // Find the first record of the model in the database with a particular id.
@@ -46,7 +49,10 @@ func (q *Query) Find(model interface{}, id interface{}) error {
 //
 //	c.First(&User{})
 func (c *Connection) First(model interface{}) error {
-	return Q(c).First(model)
+	q := Q(c)
+	q.eager = c.eager
+	q.eagerFields = c.eagerFields
+	return q.First(model)
 }
 
 // First record of the model in the database that matches the query.
@@ -76,7 +82,10 @@ func (q *Query) First(model interface{}) error {
 //
 //	c.Last(&User{})
 func (c *Connection) Last(model interface{}) error {
-	return Q(c).Last(model)
+	q := Q(c)
+	q.eager = c.eager
+	q.eagerFields = c.eagerFields
+	return q.Last(model)
 }
 
 // Last record of the model in the database that matches the query.
@@ -108,7 +117,10 @@ func (q *Query) Last(model interface{}) error {
 //
 //	c.All(&[]User{})
 func (c *Connection) All(models interface{}) error {
-	return Q(c).All(models)
+	q := Q(c)
+	q.eager = c.eager
+	q.eagerFields = c.eagerFields
+	return q.All(models)
 }
 
 // All retrieves all of the records in the database that match the query.

--- a/nulls/nulls.go
+++ b/nulls/nulls.go
@@ -33,6 +33,8 @@ func (nulls *Nulls) Parse(value interface{}) interface{} {
 	switch reflect.TypeOf(nulls.Value).String() {
 	case "nulls.Int":
 		return NewInt(value.(int))
+	case "nulls.Int64":
+		return NewInt64(value.(int64))
 	case "nulls.UUID":
 		return NewUUID(value.(uuid.UUID))
 	default:

--- a/nulls/nulls.go
+++ b/nulls/nulls.go
@@ -1,0 +1,50 @@
+package nulls
+
+import (
+	"database/sql/driver"
+	"reflect"
+
+	"github.com/satori/go.uuid"
+)
+
+// nullable a generic representation of nulls type.
+type nullable interface {
+	Interface() interface{}
+	Value() (driver.Value, error)
+}
+
+// Nulls a generic nulls type. something that implements
+// nullable interface. can be any of nulls.Int, nulls.uuid.UUID
+// nulls.String, etc.
+type Nulls struct {
+	Value interface{}
+}
+
+// Interface calls Interface function for value.
+func (nulls *Nulls) Interface() interface{} {
+	n := nulls.Value.(nullable)
+	return n.Interface()
+}
+
+// Parse parses the specified value to the corresponding
+// nullable type. value is one of the inner value hold
+// by a nullable type. i.e int, string, uuid.UUID etc.
+func (nulls *Nulls) Parse(value interface{}) interface{} {
+	switch reflect.TypeOf(nulls.Value).String() {
+	case "nulls.Int":
+		return NewInt(value.(int))
+	case "nulls.UUID":
+		return NewUUID(value.(uuid.UUID))
+	default:
+		return value
+	}
+}
+
+// New returns a wrapper called nulls for the
+// interface passed as a param.
+func New(i interface{}) *Nulls {
+	if _, ok := i.(nullable); !ok {
+		return nil
+	}
+	return &Nulls{Value: i}
+}

--- a/query.go
+++ b/query.go
@@ -69,20 +69,10 @@ func (q *Query) RawQuery(stmt string, args ...interface{}) *Query {
 //
 // 	c.Eager().Find(model, 1) // will load all associations for model.
 // 	c.Eager("Books").Find(model, 1) // will load only Book association for model.
-func (c *Connection) Eager(fields ...string) *Query {
-	return Q(c).Eager(fields...)
-}
-
-// Eager will enable load associations of the model.
-// by defaults loads all the associations on the model,
-// but can take a variadic list of associations to load.
-//
-// 	q.Eager().Find(model, 1) // will load all associations for model.
-// 	q.Eager("Books").Find(model, 1) // will load only Book association for model.
-func (q *Query) Eager(fields ...string) *Query {
-	q.eager = true
-	q.eagerFields = append(q.eagerFields, fields...)
-	return q
+func (c *Connection) Eager(fields ...string) *Connection {
+	c.eager = true
+	c.eagerFields = append(c.eagerFields, fields...)
+	return c
 }
 
 // Where will append a where clause to the query. You may use `?` in place of
@@ -91,7 +81,10 @@ func (q *Query) Eager(fields ...string) *Query {
 // 	c.Where("id = ?", 1)
 // 	q.Where("id in (?)", 1, 2, 3)
 func (c *Connection) Where(stmt string, args ...interface{}) *Query {
-	return Q(c).Where(stmt, args...)
+	q := Q(c)
+	q.eager = c.eager
+	q.eagerFields = c.eagerFields
+	return q.Where(stmt, args...)
 }
 
 // Where will append a where clause to the query. You may use `?` in place of


### PR DESCRIPTION
@markbates this is a WIP for creating eager associations. This add the ability to define a model and associations once and by using `Eager` function, it will enable `pop` to create the model and associations related.

```go
type User struct {
   ID           int        `db:"id"`
   Name         string     `db:"name"`
   FavoriteSong Song       `has_one:"song"`
   Books        Books      `has_many:"books"`
   Houses       Addresses  `many_to_many:"users_addresses"` 
}
```

```go
 u := User{
   Name: "Larry",
   FavoriteSong: Song{
      Title: "Hook - Blues Traveler"
   },
   Books: Books{
     Book{Description: "Pop Associations"},
   },
   Houses: Addresses{
     Address{Street: "Home St"},
  }
}
```

```go
tx.Eager().Create(&u)
```